### PR TITLE
Get colour-space information so that programs can handle RGB streams.

### DIFF
--- a/VPXDecoder.cpp
+++ b/VPXDecoder.cpp
@@ -33,7 +33,8 @@
 VPXDecoder::VPXDecoder(const WebMDemuxer &demuxer, unsigned threads) :
 	m_ctx(NULL),
 	m_iter(NULL),
-	m_delay(0)
+	m_delay(0),
+	m_last_space(VPX_CS_UNKNOWN)
 {
 	if (threads > 8)
 		threads = 8;

--- a/VPXDecoder.cpp
+++ b/VPXDecoder.cpp
@@ -86,6 +86,11 @@ VPXDecoder::IMAGE_ERROR VPXDecoder::getImage(Image &image)
 	IMAGE_ERROR err = NO_FRAME;
 	if (vpx_image_t *img = vpx_codec_get_frame(m_ctx, &m_iter))
 	{
+		// It seems to be a common problem that UNKNOWN comes up a lot, yet FFMPEG is somehow getting accurate colour-space information.
+		// After checking FFMPEG code, *they're* getting colour-space information, so I'm assuming something like this is going on.
+		// It appears to work, at least.
+		if (img->cs != VPX_CS_UNKNOWN)
+			m_last_space = img->cs;
 		if ((img->fmt & VPX_IMG_FMT_PLANAR) && !(img->fmt & (VPX_IMG_FMT_HAS_ALPHA | VPX_IMG_FMT_HIGHBITDEPTH)))
 		{
 			if (img->stride[0] && img->stride[1] && img->stride[2])
@@ -95,6 +100,7 @@ VPXDecoder::IMAGE_ERROR VPXDecoder::getImage(Image &image)
 
 				image.w = img->d_w;
 				image.h = img->d_h;
+				image.cs = m_last_space;
 				image.chromaShiftW = img->x_chroma_shift;
 				image.chromaShiftH = img->y_chroma_shift;
 

--- a/VPXDecoder.hpp
+++ b/VPXDecoder.hpp
@@ -41,6 +41,7 @@ public:
 		int getHeight(int plane) const;
 
 		int w, h;
+		int cs;
 		int chromaShiftW, chromaShiftH;
 		unsigned char *planes[3];
 		int linesize[3];
@@ -73,6 +74,7 @@ private:
 	vpx_codec_ctx *m_ctx;
 	const void *m_iter;
 	int m_delay;
+	int m_last_space;
 };
 
 #endif // VPXDECODER_HPP


### PR DESCRIPTION
This is primarily meant to allow godotengine/godot#26051 to work, but should be useful for other players too.

This is an ABI (but not API)-breaking commit, as Image's size increases.

ffmpeg tends to produce 'BGRP' streams, particularly in a
 Blender->AVI Raw->ffmpeg pipeline.
These streams have the ffmpeg name 'bgrp', are in a YUV444P format, and can only be differentiated by colourspace (which is of course entirely different to YUV, so they appear very broken if colourspace is not checked).

Allow a player to detect these by exposing the image colourspace.
As the colourspace may change to UNKNOWN in these files, capture any
 non-UNKNOWN colourspace.